### PR TITLE
Upgrade qdownload to iqfeed 6.2 

### DIFF
--- a/iqfeed.go
+++ b/iqfeed.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/apex/log"
@@ -34,7 +33,6 @@ const (
 type DownloadFunc func(string, *Config)
 
 var (
-	previousRequestId int64 = 0
 	sourceLocation    *time.Location
 )
 
@@ -106,15 +104,14 @@ func download(symbol string, createRequest requestFactory, rowMapper rowMapper, 
 
 	// Set protocol
 	_, err = fmt.Fprintf(conn, "S,SET PROTOCOL,%s\r\n", config.protocol)
-
 	if err != nil {
 		ctx.WithError(err).Error("Could not set protocol")
 		return
 	}
 
 	// Send request
-	requestId := fmt.Sprintf("%d", atomic.AddInt64(&previousRequestId, 1))
-	request := createRequest(symbol, requestId, config)
+	requestId := "LH"
+	request := createRequest(symbol, "", config)
 	ctx.Debug(request)
 	_, err = fmt.Fprintf(conn, "%s\r\n", request)
 
@@ -303,7 +300,7 @@ func millisecondsTimestamp() int64 {
 
 func createEodRequest(symbol string, requestId string, config *Config) string {
 	// HDT,[Symbol],[BeginDate],[EndDate],[MaxDatapoints],[DataDirection],[RequestID],[DatapointsPerSend]<CR><LF>
-	return fmt.Sprintf("HDT,%s,%s,%s,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, requestId)
+	return fmt.Sprintf("HDT,%s,%s,%s,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, "")
 }
 
 func mapEodBar(iqfeedRow []string, tz *time.Location, config *Config) (outputRow string, err error) {
@@ -330,7 +327,7 @@ func mapEodBar(iqfeedRow []string, tz *time.Location, config *Config) (outputRow
 
 func createMinuteRequest(symbol string, requestId string, config *Config) string {
 	// HIT,[Symbol],[Interval],[BeginDate BeginTime],[EndDate EndTime],[MaxDatapoints],[BeginFilterTime],[EndFilterTime],[DataDirection],[RequestID],[DatapointsPerSend],[IntervalType],[LabelAtBeginning]<CR><LF>
-	return fmt.Sprintf("HIT,%s,60,%s,%s,,,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, requestId)
+	return fmt.Sprintf("HIT,%s,60,%s,%s,,,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, "")
 }
 
 func mapMinuteBar(iqfeedRow []string, tz *time.Location, config *Config) (outputRow string, err error) {
@@ -378,7 +375,7 @@ func createIntervalRequest(symbol string, requestId string, config *Config) stri
 		label = ",1"
 	}
 
-	return fmt.Sprintf("HIT,%s,%d,%s,%s,,,,1,%s,,%s%s", strings.ToUpper(symbol), config.intervalLength, config.startDate, config.endDate, requestId, config.intervalType, label)
+	return fmt.Sprintf("HIT,%s,%d,%s,%s,,,,1,%s,,%s%s", strings.ToUpper(symbol), config.intervalLength, config.startDate, config.endDate, "", config.intervalType, label)
 }
 
 func mapIntervalBar(iqfeedRow []string, tz *time.Location, config *Config) (outputRow string, err error) {
@@ -412,7 +409,7 @@ func mapIntervalBar(iqfeedRow []string, tz *time.Location, config *Config) (outp
 
 func createTickRequest(symbol string, requestId string, config *Config) string {
 	// HTT,[Symbol],[BeginDate BeginTime],[EndDate EndTime],[MaxDatapoints],[BeginFilterTime],[EndFilterTime],[DataDirection],[RequestID],[DatapointsPerSend]<CR><LF>
-	return fmt.Sprintf("HTT,%s,%s,%s,,,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, requestId)
+	return fmt.Sprintf("HTT,%s,%s,%s,,,,1,%s", strings.ToUpper(symbol), config.startDate, config.endDate, "")
 }
 
 func mapTick(iqfeedRow []string, tz *time.Location, config *Config) (outputRow string, err error) {

--- a/iqfeed_test.go
+++ b/iqfeed_test.go
@@ -20,7 +20,7 @@ var (
 	testTooFewColumnsIqfeedEodBar    = "999,2019-02-21,24.0600,23.8038,23.8700,24.0000,29183"
 	testValidIqfeedMinuteBar         = "999,2019-02-26 12:22:00,23.8000,23.8000,23.8000,23.8000,13578,100,0,"
 	testTooFewColumnsIqfeedMinuteBar = "999,2019-02-26 12:22:00,23.8000,23.8000,23.8000,23.8000"
-	testValidIqfeedTick              = "999,2019-02-25 11:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,"
+	testValidIqfeedTick              = "999,2019-02-25 11:30:06.691000,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,0,13"
 	testTooFewColumnsIqfeedTick      = "999,2019-02-25 11:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25"
 	testIncorrectRequestIdIqfeedTick = "111,2019-02-25 11:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,"
 	et                               *time.Location
@@ -42,7 +42,7 @@ func TestMapRow(t *testing.T) {
 
 		mappedRow, err := mapRow(columns, testRequestId, mapTick, et, createConfig(0, "", false, false))
 
-		assert.Equal(t, "2019-02-25 11:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87", mappedRow)
+		assert.Equal(t, "2019-02-25 11:30:06.691000,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,0,13", mappedRow)
 		assert.Nil(t, err)
 	})
 
@@ -51,7 +51,7 @@ func TestMapRow(t *testing.T) {
 
 		mappedRow, err := mapRow(columns, testRequestId, mapTick, et, createConfig(0, "", false, true))
 
-		assert.Equal(t, "2019-02-25 11:30:06.691\t23.8800\t12\t6714\t23.8700\t23.9700\t6\tO\t25\t3D87", mappedRow)
+		assert.Equal(t, "2019-02-25 11:30:06.691000\t23.8800\t12\t6714\t23.8700\t23.9700\t6\tO\t25\t3D87\t0\t13", mappedRow)
 		assert.Nil(t, err)
 	})
 
@@ -244,7 +244,7 @@ func TestTickMapper(t *testing.T) {
 
 		mappedRow, err := mapTick(columns, et, createConfig(0, "", false, false))
 
-		assert.Equal(t, "2019-02-25 11:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87", mappedRow)
+		assert.Equal(t, "2019-02-25 11:30:06.691000,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,0,13", mappedRow)
 		assert.Nil(t, err)
 	})
 
@@ -254,7 +254,7 @@ func TestTickMapper(t *testing.T) {
 
 		mappedRow, err := mapTick(columns, cst, createConfig(0, "", false, false))
 
-		assert.Equal(t, "2019-02-25 10:30:06.691,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87", mappedRow)
+		assert.Equal(t, "2019-02-25 10:30:06.691000,23.8800,12,6714,23.8700,23.9700,6,O,25,3D87,0,13", mappedRow)
 		assert.Nil(t, err)
 	})
 

--- a/iqfeed_test.go
+++ b/iqfeed_test.go
@@ -281,7 +281,7 @@ func TestCreateEodRequest(t *testing.T) {
 	t.Run("eod request", func(t *testing.T) {
 		request := createEodRequest("spy", "R91", createConfig(0, "", false, false))
 
-		assert.Equal(t, "HDT,SPY,20190122,20190221,,1,R91", request)
+		assert.Equal(t, "HDT,SPY,20190122,20190221,,1,", request)
 	})
 }
 
@@ -289,7 +289,7 @@ func TestCreateMinuteRequest(t *testing.T) {
 	t.Run("minute request", func(t *testing.T) {
 		request := createMinuteRequest("spy", "R91", createConfig(0, "", false, false))
 
-		assert.Equal(t, "HIT,SPY,60,20190122,20190221,,,,1,R91", request)
+		assert.Equal(t, "HIT,SPY,60,20190122,20190221,,,,1,", request)
 	})
 }
 
@@ -297,12 +297,12 @@ func TestCreateIntervalRequest(t *testing.T) {
 	t.Run("interval request with bar start timestamp", func(t *testing.T) {
 		request := createIntervalRequest("spy", "R91", createConfig(5, "S", false, false))
 
-		assert.Equal(t, "HIT,SPY,5,20190122,20190221,,,,1,R91,,S,1", request)
+		assert.Equal(t, "HIT,SPY,5,20190122,20190221,,,,1,,,S,1", request)
 	})
 	t.Run("interval request with bar end timestamp", func(t *testing.T) {
 		request := createIntervalRequest("spy", "R91", createConfig(5, "S", true, false))
 
-		assert.Equal(t, "HIT,SPY,5,20190122,20190221,,,,1,R91,,S", request)
+		assert.Equal(t, "HIT,SPY,5,20190122,20190221,,,,1,,,S", request)
 	})
 }
 
@@ -310,7 +310,7 @@ func TestCreateTickRequest(t *testing.T) {
 	t.Run("tick request", func(t *testing.T) {
 		request := createTickRequest("spy", "R91", createConfig(0, "", false, false))
 
-		assert.Equal(t, "HTT,SPY,20190122,20190221,,,,1,R91", request)
+		assert.Equal(t, "HTT,SPY,20190122,20190221,,,,1,", request)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -178,11 +178,11 @@ func mapIntervalType(argument string, intervalType *string) error {
 	arg := strings.ToUpper(argument)
 
 	if strings.HasPrefix(arg, "S") {
-		*intervalType = "S"
+		*intervalType = "s"
 	} else if strings.HasPrefix(arg, "V") {
-		*intervalType = "V"
+		*intervalType = "v"
 	} else if strings.HasPrefix(arg, "T") {
-		*intervalType = "T"
+		*intervalType = "t"
 	} else {
 		return fmt.Errorf("incorrect interval type: %s", argument)
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type Config struct {
@@ -203,6 +204,17 @@ func showUsageWithError(c *cli.Context, message string) error {
 func runCommand(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return showUsageWithError(c, "Comma separated symbols or symbols filename argument missing")
+	}
+
+	if c.Command.Name == "eod" && config.startDate == "" && config.endDate == "" {
+		log.Debug("[start|enddate required] set enddate=tomorrow")
+		config.endDate = time.Now().Add(24 * time.Hour).Format("20060102")
+	} else if c.Command.Name == "minute" && config.startDate == "" && config.endDate == "" {
+		log.Debug("[start|enddate required] set enddate=tomorrow")
+		config.endDate = time.Now().Add(24 * time.Hour).Format("20060102 150405")
+	} else if c.Command.Name == "interval" && config.startDate == "" && config.endDate == "" {
+		log.Debug("[start|enddate required] set enddate=tomorrow")
+		config.endDate = time.Now().Add(24 * time.Hour).Format("20060102 150405")
 	}
 
 	config.command = c.Command.Name

--- a/main.go
+++ b/main.go
@@ -32,10 +32,8 @@ type Config struct {
 }
 
 var (
-	newProtocol = "6.0"
-
 	config = Config{
-		protocol:        "5.1",
+		protocol:        "6.2",
 		command:         "",
 		startDate:       "",
 		endDate:         "",
@@ -160,13 +158,6 @@ func main() {
 					err = fmt.Errorf("incorrect interval length: %s", c.Args()[0])
 				} else {
 					err = mapIntervalType(config.intervalType, &config.intervalType)
-				}
-
-				if !config.endTimestamp {
-					log.Infof("Using newer protocol required for bar start timestamps, "+
-						"requiring at least IQFeed %s", newProtocol)
-					config.protocol = newProtocol
-					config.useLabels = true
 				}
 
 				return err

--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func runCommand(c *cli.Context) error {
 		return err
 	}
 
+	log.Debug(fmt.Sprintf("config=%+v\n", config))
 	wg := start(symbols, &config)
 
 	wg.Wait()


### PR DESCRIPTION
Hello,

I took the liberty to upgrade your qdownload tool from iqfeed protocol 5.1 to the latest 6.2 and add some small changes I thought are useful.

Changes I've done:
* (protocol) Fix intervalTypes must be lowercase
* (feature) If no begin or endate set enddate=tomorrow
* (feature) print config in detailed-logging
* (protocol) removed requestID (field 0 is now the new messageid LM)
* (protocol) added tradeaggresor/daycode/microseconds to tickdata